### PR TITLE
fix: search init to hide text

### DIFF
--- a/app/components/toolbar/toolbar.factory.js
+++ b/app/components/toolbar/toolbar.factory.js
@@ -35,6 +35,7 @@
                     init: function() {
                         toolbar.props.search.value = '';
                         this.hideButton();
+                        this.hideText();
                     },
                     blur: function() {
                         if (toolbar.props.search.value === undefined || toolbar.props.search.value.length < 1) {


### PR DESCRIPTION
if searched for then select or add, on return from edit the search text
was still being displayed.